### PR TITLE
chore: Release sync from zCFD v2025.11.13331.5-test

### DIFF
--- a/.github/workflows/zutil-pypi-release.yml
+++ b/.github/workflows/zutil-pypi-release.yml
@@ -98,7 +98,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.get_tag.outputs.tag_name }}
-          release_name: zUtil ${{ steps.get_tag.outputs.tag_name }}${{ steps.get_tag.outputs.test_mode == 'true' && ' (TEST)' || '' }}
+          release_name: ${{ steps.get_tag.outputs.tag_name }}${{ steps.get_tag.outputs.test_mode == 'true' && ' (TEST)' || '' }}
           body: |
             ## zUtil Release ${{ steps.get_tag.outputs.tag_name }}${{ steps.get_tag.outputs.test_mode == 'true' && ' (TEST)' || '' }}
             


### PR DESCRIPTION
Automated sync from zenotech/zCFD

**Source tag:** v2025.11.13331.5-test
**Source ref:** ZCFD-1678-copybara2
**Source commit:** 57c8e958108cfb15f8a3ca5683a40d1f4c61d16b