### PR TITLE
chore: Release sync from zCFD v2025.11.13331.8-test

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -72,9 +72,8 @@ jobs:
             fi
           fi
           
-          # Extract clean version: remove 'v' prefix and '-test' suffix
+          # Extract clean version: remove '-test' suffix but keep 'v' prefix
           VERSION="$TAG"
-          VERSION="${VERSION#v}"        # Remove 'v' prefix
           VERSION="${VERSION%-test}"    # Remove '-test' suffix
           
           echo "tag_name=$TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Automated sync from zenotech/zCFD

**Source tag:** v2025.11.13331.8-test
**Source ref:** ZCFD-1678-copybara2
**Source commit:** 0b8c71e67850e42e241de91d830b06a810bce1d8