### PR TITLE
chore: Release sync from zCFD v2025.11.13331.9-test

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/zutil
     permissions:
       id-token: write  # Required for trusted publishing
 


### PR DESCRIPTION
Automated sync from zenotech/zCFD

**Source tag:** v2025.11.13331.9-test
**Source ref:** ZCFD-1678-copybara2
**Source commit:** 34a7a3a9a855db5b347389d7040b62a3811534ac