### PR TITLE
chore: Release sync from zCFD v2025.11.13331.11

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - name: Debug release event
@@ -75,6 +77,3 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          verbose: true
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Automated sync from zenotech/zCFD

**Source tag:** v2025.11.13331.11
**Source ref:** ZCFD-1678-copybara2
**Source commit:** e760a6c3839df0dcf907300686dda99a873cccfc